### PR TITLE
Fix connection string consistency and add app name

### DIFF
--- a/app/AdminApplication/AdminSite/Program.cs
+++ b/app/AdminApplication/AdminSite/Program.cs
@@ -34,7 +34,7 @@ builder.Services.AddAWSService<IAmazonRekognition>();
 builder.Services.AddAWSService<IAmazonTranslate>();
 builder.Services.AddCognitoIdentity();
 builder.Services.AddDefaultAWSOptions(builder.Configuration.GetAWSOptions());
-builder.Services.AddDbContext<ApplicationDbContext>(option => option.UseSqlServer(builder.Configuration.GetConnectionString("BobsBookstoreContextConnection")));
+builder.Services.AddDbContext<ApplicationDbContext>(option => option.UseSqlServer(builder.Configuration.GetConnectionString("BookstoreDbDefaultConnection")));
 builder.Services.AddTransient<ISearchDatabaseCalls, SearchDatabaseCalls>();
 builder.Services.AddTransient<IExpressionFunction, ExpressionFunction>();
 builder.Services.AddTransient<IOrderDatabaseCalls, OrderDatabaseCalls>();

--- a/app/AdminApplication/AdminSite/appsettings.Development.json
+++ b/app/AdminApplication/AdminSite/appsettings.Development.json
@@ -8,7 +8,7 @@
     }
   },
   "ConnectionStrings": {
-    "BobsBookstoreContextConnection": "Server=(localdb)\\MSSQLLocalDB; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security= true",
+    "BookstoreDbDefaultConnection": "Server=(localdb)\\MSSQLLocalDB; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security= true; Application Name=AdminSiteDev",
     "FromEmailAddress": "test@email.com",
     "ToEmailAddressDefault": "test@email.com"
   }

--- a/app/AdminApplication/AdminSite/appsettings.json
+++ b/app/AdminApplication/AdminSite/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server={0},{1}; Initial Catalog=BobsUsedBookStore; Integrated Security= false",
+    "BookstoreDbDefaultConnection": "Server={0},{1}; Initial Catalog=BobsUsedBookStore; Integrated Security= false; Application Name=AdminSite",
     "FromEmailAddress": "test@email.com",
     "ToEmailAddressDefault": "test@email.com"
   },
@@ -26,5 +26,3 @@
   },
   "AllowedHosts": "*"
 }
-
- 

--- a/app/CustomerApplication/CustomerSite/Startup.cs
+++ b/app/CustomerApplication/CustomerSite/Startup.cs
@@ -51,7 +51,7 @@ namespace CustomerSite
             services.AddCognitoIdentity();
             services.AddRazorPages();
 
-            var connectionString = Configuration.GetConnectionString("BobsBookstoreContextConnection");
+            var connectionString = Configuration.GetConnectionString("BookstoreDbDefaultConnection");
 
             if (!CurrentEnvironment.IsDevelopment())
             {
@@ -111,7 +111,7 @@ namespace CustomerSite
 
         private string GetConnectionString(AWSOptions awsOptions)
         {
-            var connString = Configuration.GetConnectionString("BobsBookstoreContextConnection");
+            var connString = Configuration.GetConnectionString("BookstoreDbDefaultConnection");
             try
             {
                 Console.WriteLine("Non-development mode, building connection string for SQL Server");

--- a/app/CustomerApplication/CustomerSite/appsettings.Development.json
+++ b/app/CustomerApplication/CustomerSite/appsettings.Development.json
@@ -7,7 +7,6 @@
     }
   },
   "ConnectionStrings": {
-    "BobsBookstoreContextConnection": "Server=(localdb)\\MSSQLLocalDB; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security= true"
+    "BookstoreDbDefaultConnection": "Server=(localdb)\\MSSQLLocalDB; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security= true; ApplicationName=BookstoreSiteDev"
   }
 }
-

--- a/app/CustomerApplication/CustomerSite/appsettings.json
+++ b/app/CustomerApplication/CustomerSite/appsettings.json
@@ -9,6 +9,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "BobsBookstoreContextConnection": "Server={0},{1}; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security=false"
+    "BookstoreDbDefaultConnection": "Server={0},{1}; Initial Catalog=BobsUsedBookStore;MultipleActiveResultSets=true; Integrated Security=false; ApplicationName=BookstoreSite"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use consistent naming for connection strings. Added application name to aid if diagnosing issues between admin and customer facing sites.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
