### PR TITLE
Apply same AssumedBy trust for admin and customer site app roles

### DIFF
--- a/infrastructure/SharedInfrastructure/src/SharedInfrastructure/ProductionStack.cs
+++ b/infrastructure/SharedInfrastructure/src/SharedInfrastructure/ProductionStack.cs
@@ -604,7 +604,11 @@ public class ProductionStack : Stack
         // credentials via a trust relationship
         var customerAppRole = new Role(this, "CustomerApplicationRole", new RoleProps
         {
-            AssumedBy = new ServicePrincipal("ec2.amazonaws.com"),
+            AssumedBy = new CompositePrincipal(
+                new ServicePrincipal("ec2.amazonaws.com"),
+                new ServicePrincipal("tasks.apprunner.amazonaws.com"),
+                new ServicePrincipal("ecs-tasks.amazonaws.com")
+            ),
             ManagedPolicies = new []
             {
                 ManagedPolicy.FromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"),


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updated customer website app role to use the same trust principals as the admin web site, so the customer app can be deployed to AppRunner etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
