### PR TITLE
Updated the CDK Nuget package to fix the node version issue while creating lambda functions

### DIFF
--- a/app/Bookstore.Cdk/Bookstore.Cdk.csproj
+++ b/app/Bookstore.Cdk/Bookstore.Cdk.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <!-- CDK Construct Library dependencies -->
-        <PackageReference Include="Amazon.CDK.Lib" Version="2.55.*" />
+        <PackageReference Include="Amazon.CDK.Lib" Version="2.130.0" />
         <PackageReference Include="Constructs" Version="10.1.*" />
 
         <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/app/Bookstore.Cdk/DatabaseStack.cs
+++ b/app/Bookstore.Cdk/DatabaseStack.cs
@@ -46,7 +46,7 @@ public class DatabaseStack : Stack
             {
                 dbSG
             },
-            InstanceType = InstanceType.Of(InstanceClass.BURSTABLE2, InstanceSize.MICRO),
+            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE2, InstanceSize.MICRO),
             InstanceIdentifier = $"{Constants.AppName}Database",
             // As this is a sample app, turn off automated backups to avoid any storage costs
             // of automated backup snapshots. It also helps the stack launch a little faster by

--- a/app/Bookstore.Cdk/EC2ComputeStack.cs
+++ b/app/Bookstore.Cdk/EC2ComputeStack.cs
@@ -193,7 +193,7 @@ public class EC2ComputeStack : Stack
             Vpc = props.Vpc,
             VpcSubnets = new SubnetSelection { SubnetType = SubnetType.PUBLIC },
             SecurityGroup = webAppSecurityGroup,
-            InstanceType = InstanceType.Of(InstanceClass.BURSTABLE3, InstanceSize.SMALL),
+            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE3, InstanceSize.SMALL),
             MachineImage = ami,
             Role = this.Ec2Role,
             RequireImdsv2 = true,


### PR DESCRIPTION
*Description of changes:*
CDK deploy was failing due to runtime parameter of nodejs14.x no longer being supported for creating or updating AWS Lambda functions. Updated the CDK NuGet package to resolve the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
