### PR TITLE
RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.small, Engine=sqlserver-ex, EngineVersion=14.00.3465.1.v1,

### DIFF
--- a/app/Bookstore.Cdk/DatabaseStack.cs
+++ b/app/Bookstore.Cdk/DatabaseStack.cs
@@ -46,7 +46,7 @@ public class DatabaseStack : Stack
             {
                 dbSG
             },
-            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE2, InstanceSize.MICRO),
+            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE3, InstanceSize.MICRO),
             InstanceIdentifier = $"{Constants.AppName}Database",
             // As this is a sample app, turn off automated backups to avoid any storage costs
             // of automated backup snapshots. It also helps the stack launch a little faster by


### PR DESCRIPTION
RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.small, Engine=sqlserver-ex, EngineVersion=14.00.3465.1.v1,

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
