### PR TITLE
Update RDS instance type and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ To run the application using the _Integrated_ profile a minimal set of AWS resou
 
 1. Open a command-line shell and navigate to the application solution folder (the folder that contains _BobsBookstore.sln_).
 
+1. In the command-line shell run the command `dotnet publish app/Bookstore.Web/Bookstore.Web.csproj -p:PublishProfile=FolderProfile -c Release`
+![Publish the application](./media/publish.png)
+
 1. [Bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) your AWS environment for the AWS CDK by running the command `cdk bootstrap`
 
 1. In the command-line shell run the command `cdk deploy BobsBookstoreCore --require-approval "never"`. This will take about 5 minutes to complete.
@@ -104,10 +107,10 @@ In addition to the AWS resources that are created and used by the [_Integrated_ 
 
 1. Open a command-line shell and navigate to the application solution folder (the folder that contains _BobsBookstore.sln_).
 
-1. If you haven't done so already, [Bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) your AWS environment for the AWS CDK by running the command `cdk bootstrap`
-
 1. In the command-line shell run the command `dotnet publish app/Bookstore.Web/Bookstore.Web.csproj -p:PublishProfile=FolderProfile -c Release`
 ![Publish the application](./media/publish.png)
+
+1. If you haven't done so already, [Bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) your AWS environment for the AWS CDK by running the command `cdk bootstrap`
 
 1. In the command-line shell run the command `cdk deploy BobsBookstoreEC2 --require-approval "never"`. This will take about 25 minutes to complete.
 

--- a/app/Bookstore.Cdk/DatabaseStack.cs
+++ b/app/Bookstore.Cdk/DatabaseStack.cs
@@ -33,7 +33,7 @@ public class DatabaseStack : Stack
             {
                 SubnetType = SubnetType.PRIVATE_WITH_EGRESS
             },
-            // SQL Server 2017 Express Edition, in conjunction with a db.t2.micro instance type,
+            // SQL Server 2017 Express Edition, in conjunction with a db.t3.micro instance type,
             // fits inside the free tier for new accounts
             Engine = DatabaseInstanceEngine.SqlServerEx(new SqlServerExInstanceEngineProps
             {
@@ -46,7 +46,7 @@ public class DatabaseStack : Stack
             {
                 dbSG
             },
-            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE2, InstanceSize.MICRO),
+            InstanceType = Amazon.CDK.AWS.EC2.InstanceType.Of(InstanceClass.BURSTABLE3, InstanceSize.MICRO),
             InstanceIdentifier = $"{Constants.AppName}Database",
             // As this is a sample app, turn off automated backups to avoid any storage costs
             // of automated backup snapshots. It also helps the stack launch a little faster by


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [CDK bootstrap synthesizes the application by default](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-bootstrap), which requires the published assets to be on disk prior to running `cdk bootstrap`. The current instructions for deployment lead to errors due to missing/out of order steps. To solve this, I added a publish step to [Integrated deployment](https://github.com/aws-samples/bobs-used-bookstore-sample?tab=readme-ov-file#running-and-debugging-with-the-integrated-launch-profile) section of README, and reordered the [Full deployment](https://github.com/aws-samples/bobs-used-bookstore-sample?tab=readme-ov-file#perform-a-full-deployment) steps so that the publish step comes before `cdk bootstrap`.
- Changed database instance type in DatabaseStack to **t3.micro** from **t2.micro** since t2.micro isn't supported anymore by RDS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
